### PR TITLE
scan app/node_modules for beaker plugins, not global-modules. Remove …

### DIFF
--- a/app/background-process/plugin-modules.js
+++ b/app/background-process/plugin-modules.js
@@ -3,25 +3,18 @@ import path from 'path'
 import fs from 'fs'
 import log from 'loglevel'
 import rpc from 'pauls-electron-rpc'
-import globalModulesDir from 'global-modules'
 import manifest from './api-manifests/plugin-modules'
 
-// globals
-// =
+const appNodeModules = path.resolve( __dirname, 'node_modules' );
 
 // load all global modules named beaker-plugin-*
 var protocolModuleNames = []
 try {
-  protocolModuleNames = fs.readdirSync(globalModulesDir).filter(name => name.startsWith('beaker-plugin-'))
-} catch (e) {}
-var protocolModules = protocolModuleNames.map(name => require(path.join(globalModulesDir, name)))
-
-// load builtin
-if (!protocolModuleNames.includes('beaker-plugin-dat'))
-  protocolModules.push(require('beaker-plugin-dat'))
-if (!protocolModuleNames.includes('beaker-plugin-ipfs'))
-  protocolModules.push(require('beaker-plugin-ipfs'))
-
+  protocolModuleNames = fs.readdirSync( appNodeModules  ).filter(name => name.startsWith('beaker-plugin-') )
+} catch (e) {
+    console.log( "Error with reading app/node_modules", e )
+}
+var protocolModules = protocolModuleNames.map(name => require(path.join( appNodeModules, name)))
 
 // exported api
 // =

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,6 @@
     "electron-localshortcut": "^0.6.0",
     "emit-stream": "^0.1.2",
     "fs-jetpack": "^0.9.0",
-    "global-modules": "^0.2.3",
     "loglevel": "^1.4.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.13.0",


### PR DESCRIPTION
…global-modules from package.json.

Also removes default inclusion of dat/ipfs if not found in globals.

For https://github.com/pfrazee/beaker/issues/56