### PR TITLE
add open-url support

### DIFF
--- a/app/background-process.js
+++ b/app/background-process.js
@@ -3,7 +3,7 @@
 // It doesn't have any windows which you can see on screen, but we can open
 // window from here.
 
-import { app, Menu } from 'electron'
+import { app, Menu, ipcMain } from 'electron'
 import log from 'loglevel'
 import env from './env'
 
@@ -58,4 +58,16 @@ app.on('window-all-closed', function () {
   // it's normal for OSX apps to stay open, even if all windows are closed
   // but, since we have an uncloseable tabs bar, let's close when they're all gone
   app.quit()
+})
+
+var queue = []
+
+app.on('open-url', function (e, url) {
+  queue.push(url)
+})
+
+ipcMain.on('shell-window-ready', function (e) {
+  queue.forEach((url) => {
+    e.sender.send('command', 'file:new-tab', url)
+  })
 })

--- a/app/background-process.js
+++ b/app/background-process.js
@@ -28,6 +28,8 @@ log.setLevel('trace')
 // load the installed protocols
 plugins.registerStandardSchemes()
 
+var win
+
 app.on('ready', function () {
   // databases
   settings.setup()
@@ -41,7 +43,7 @@ app.on('ready', function () {
   // ui
   Menu.setApplicationMenu(Menu.buildFromTemplate(buildWindowMenu(env)))
   registerContextMenu()
-  windows.setup()
+  win = windows.setup()
   downloads.setup()
 
   // protocols
@@ -61,12 +63,18 @@ app.on('window-all-closed', function () {
 })
 
 var queue = []
+var shellReady = false
 
 app.on('open-url', function (e, url) {
-  queue.push(url)
+  if (shellReady) {
+    win.webContents.send('command', 'file:new-tab', url)
+  } else {
+    queue.push(url)
+  }
 })
 
 ipcMain.on('shell-window-ready', function (e) {
+  shellReady = true
   queue.forEach((url) => {
     e.sender.send('command', 'file:new-tab', url)
   })

--- a/app/background-process.js
+++ b/app/background-process.js
@@ -54,6 +54,10 @@ app.on('ready', function () {
   // web APIs
   webAPIs.setup()
   plugins.setupWebAPIs()
+
+  win.on('closed', () => {
+    win = null
+  })
 })
 
 app.on('window-all-closed', function () {

--- a/app/background-process.js
+++ b/app/background-process.js
@@ -43,7 +43,7 @@ app.on('ready', function () {
   // ui
   Menu.setApplicationMenu(Menu.buildFromTemplate(buildWindowMenu(env)))
   registerContextMenu()
-  var win = windows.setup()
+  windows.setup()
   downloads.setup()
 
   // protocols
@@ -56,7 +56,7 @@ app.on('ready', function () {
   plugins.setupWebAPIs()
 
   // listen OSX open-url event
-  openURL.setup(win)
+  openURL.setup()
 })
 
 app.on('window-all-closed', function () {

--- a/app/background-process/api-manifests/browser.js
+++ b/app/background-process/api-manifests/browser.js
@@ -14,5 +14,9 @@ export default {
   uninstallPlugin: 'promise',
 
   getHomePages: 'promise',
-  getProtocolDescription: 'sync'
+  getProtocolDescription: 'sync',
+
+  getDefaultProtocolSettings: 'sync',
+  setAsDefaultProtocolClient: 'sync',
+  removeAsDefaultProtocolClient: 'sync'
 }

--- a/app/background-process/browser.js
+++ b/app/background-process/browser.js
@@ -56,7 +56,7 @@ export function setup () {
   setTimeout(scheduledAutoUpdate, 15e3) // wait 15s for first run
 
   // wire up RPC
-  rpc.exportAPI('beakerBrowser', manifest, { 
+  rpc.exportAPI('beakerBrowser', manifest, {
     eventsStream,
     getInfo,
     checkForUpdates,
@@ -67,8 +67,27 @@ export function setup () {
     setSetting,
 
     getProtocolDescription,
+    getDefaultProtocolSettings,
+    setAsDefaultProtocolClient,
+    removeAsDefaultProtocolClient,
     getHomePages
   })
+}
+
+export function getDefaultProtocolSettings () {
+  return ['http', 'dat', 'ipfs', 'view-dat'].reduce((res, x) => {
+    res[x] = app.isDefaultProtocolClient(x)
+    console.log(x, res[x])
+    return res
+  }, {})
+}
+
+export function setAsDefaultProtocolClient (protocol) {
+  return app.setAsDefaultProtocolClient(protocol)
+}
+
+export function removeAsDefaultProtocolClient (protocol) {
+  return app.removeAsDefaultProtocolClient(protocol)
 }
 
 export function getInfo () {

--- a/app/background-process/open-url.js
+++ b/app/background-process/open-url.js
@@ -1,26 +1,20 @@
 // handle OSX open-url event
 import { ipcMain } from 'electron'
-var shellReady = false
-var shellWindow
 var queue = []
+var commandReceiver
 
-export function setup (win) {
-  shellWindow = win
+export function setup () {
   ipcMain.on('shell-window-ready', function (e) {
-    shellReady = true
+    commandReceiver = e.sender
     queue.forEach((url) => {
-      e.sender.send('command', 'file:new-tab', url)
+      commandReceiver.send('command', 'file:new-tab', url)
     })
-  })
-
-  shellWindow.on('closed', () => {
-    shellWindow = null
   })
 }
 
 export function open (url) {
-  if (shellReady) {
-    shellWindow.webContents.send('command', 'file:new-tab', url)
+  if (commandReceiver) {
+    commandReceiver.send('command', 'file:new-tab', url)
   } else {
     queue.push(url)
   }

--- a/app/background-process/open-url.js
+++ b/app/background-process/open-url.js
@@ -1,0 +1,27 @@
+// handle OSX open-url event
+import { ipcMain } from 'electron'
+var shellReady = false
+var shellWindow
+var queue = []
+
+export function setup (win) {
+  shellWindow = win
+  ipcMain.on('shell-window-ready', function (e) {
+    shellReady = true
+    queue.forEach((url) => {
+      e.sender.send('command', 'file:new-tab', url)
+    })
+  })
+
+  shellWindow.on('closed', () => {
+    shellWindow = null
+  })
+}
+
+export function open (url) {
+  if (shellReady) {
+    shellWindow.webContents.send('command', 'file:new-tab', url)
+  } else {
+    queue.push(url)
+  }
+}

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -18,7 +18,7 @@ export function setup () {
   userDataDir = jetpack.cwd(app.getPath('userData'))
 
   // create first shell window
-  createShellWindow()
+  return createShellWindow()
 }
 
 export function createShellWindow () {

--- a/app/builtin-pages/views/settings.js
+++ b/app/builtin-pages/views/settings.js
@@ -78,7 +78,7 @@ function renderProtocolSettings () {
   return yo`<div class="s-section">
     <div>${
       Object.keys(defaultProtocolSettings).map(p => {
-        return yo`<div>${p.toUpperCase()} <a onclick=${register(p)}>Register</a> | <a onclick=${remove(p)}>Unregister</a></div>`
+        return yo`<div><b>${p.toUpperCase()}</b> <a onclick=${register(p)}>Register</a> | <a onclick=${remove(p)}>Unregister</a></div>`
       })
     }</div>
   </div>`

--- a/app/builtin-pages/views/settings.js
+++ b/app/builtin-pages/views/settings.js
@@ -12,6 +12,7 @@ import emitStream from 'emit-stream'
 var settings
 var browserInfo
 var browserEvents
+var defaultProtocolSettings
 
 // exported API
 // =
@@ -25,6 +26,7 @@ export function setup () {
 
 export function show () {
   document.title = 'Settings'
+  defaultProtocolSettings = beakerBrowser.getDefaultProtocolSettings()
   co(function* () {
     browserInfo = yield beakerBrowser.getInfo()
     settings = yield beakerBrowser.getSettings()
@@ -36,6 +38,7 @@ export function show () {
 export function hide () {
   browserInfo = null
   settings = null
+  defaultProtocolSettings = null
 }
 
 // rendering
@@ -55,8 +58,30 @@ function render () {
         <div><strong>Version:</strong> ${browserInfo.version}</div>
         <div><strong>User data:</strong> ${browserInfo.paths.userData}</div>
       </div>
+      <div class="ll-heading">Protocols</div>
+      ${renderProtocolSettings()}
     </div>
   </div>`)
+}
+
+function renderProtocolSettings () {
+  function register (protocol) {
+    return function () {
+      beakerBrowser.setAsDefaultProtocolClient(protocol)
+    }
+  }
+  function remove (protocol) {
+    return function () {
+      beakerBrowser.removeAsDefaultProtocolClient(protocol)
+    }
+  }
+  return yo`<div class="s-section">
+    <div>${
+      Object.keys(defaultProtocolSettings).map(p => {
+        return yo`<div>${p.toUpperCase()} <a onclick=${register(p)}>Register</a> | <a onclick=${remove(p)}>Unregister</a></div>`
+      })
+    }</div>
+  </div>`
 }
 
 function renderAutoUpdater () {

--- a/app/shell-window.js
+++ b/app/shell-window.js
@@ -1,8 +1,11 @@
-import { remote } from 'electron'
+import { remote, ipcRenderer } from 'electron'
 import { setup as setupUI } from './shell-window/ui'
 import importWebAPIs from './lib/fg/import-web-apis'
 const { session } = remote
 
 // setup UI
 importWebAPIs()
-setupUI()
+// background-process need to know when shell-window is ready to accept commands
+setupUI(() => {
+  ipcRenderer.send('shell-window-ready')
+})

--- a/app/shell-window/ui.js
+++ b/app/shell-window/ui.js
@@ -8,7 +8,7 @@ import * as swipeHandlers from './swipe-handlers'
 import permsPrompt from './ui/prompts/permission'
 import errorPage from '../lib/error-page'
 
-export function setup () {
+export function setup (cb) {
   if (window.process.platform == 'darwin') {
     document.body.classList.add('darwin')
   }
@@ -19,7 +19,10 @@ export function setup () {
   commandHandlers.setup()
   swipeHandlers.setup()
   remote.session.defaultSession.setPermissionRequestHandler(onPermissionRequestHandler)
-  pages.loadPinnedFromDB().then(() => pages.setActive(pages.create(pages.DEFAULT_URL)))
+  pages.loadPinnedFromDB().then(() => {
+    pages.setActive(pages.create(pages.DEFAULT_URL))
+    cb()
+  })
 }
 
 function onProtocolNotSupported (webContents) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,18 @@
       {
         "name": "URL",
         "schemes": ["http", "https"]
+      },
+      {
+        "name": "IPFS",
+        "schemes": ["ipfs"]
+      },
+      {
+        "name": "dat",
+        "schemes": ["dat"]
+      },
+      {
+        "name": "view-dat",
+        "schemes": ["view-dat"]
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,17 @@
     "category": "public.app-category.productivity",
     "copyright": "© 2016, Paul Frazee",
     "npmRebuild": false,
-    "asar": false
+    "asar": false,
+    "protocols": [
+      {
+        "name": "URL",
+        "schemes": ["http", "https"]
+      },
+      {
+        "name": "File",
+        "schemes": ["file"]
+      }
+    ]
   },
   "scripts": {
     "postinstall": "cd app && npm install",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,6 @@
       {
         "name": "URL",
         "schemes": ["http", "https"]
-      },
-      {
-        "name": "File",
-        "schemes": ["file"]
       }
     ]
   },


### PR DESCRIPTION
In order to make this work, `background-process` need to know when `shell-window` is ready, then send `file:new-tab` command to shell-window.

- add 'shell-window-ready' event to indicate shell-window is ready
- add app listener for `open-url` event.
- add `http` and `https` protocol to `package.json` so on OSX we can go `system perferences` -> `general` -> `default browser` and select beaker!

<img width="279" alt="2016-09-05 5 08 07" src="https://cloud.githubusercontent.com/assets/8631/18242995/7879609e-738b-11e6-838e-7c578fe68009.png">

fix #77 