### PR TITLE
revert any editing in navbar when ESC is pressed, not just remove focus.

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -467,6 +467,8 @@ function onInputLocation (e) {
 function onKeydownLocation (e) {
   // on escape
   if (e.keyCode == KEYCODE_ESC) {
+    var page = getEventPage(e)
+    page.navbarEl.querySelector('.nav-location-input').value = page.getURL()
     e.target.blur()
     return
   }


### PR DESCRIPTION
A minor usability issue here. 

In Chrome, if we press ESC when editing navbar, the value of navbar will be reverted to the page's URL. In safari, we need to press ESC 2 times to achieve the same effect.

This PR will mimic the experience in Chrome, which take 1 ESC key press to revert the changes.

Feel free to close this PR if you don't like this behaviour.